### PR TITLE
Recover record expression types after semantic errors

### DIFF
--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -98,10 +98,14 @@ module Semant : SEMANT = struct
       | A.OpExp { left; oper; right; pos } when A.is_comparison_op oper -> (
           let { ty = left_ty; exp = left_exp } = trexp left in
           let { ty = right_ty; exp = right_exp } = trexp right in
-          let left_ty = actual_ty left_ty in
-          let right_ty = actual_ty right_ty in
-          match left_ty with
-          | Types.INT | Types.STRING | Types.NIL | Types.RECORD _
+           let left_ty = actual_ty left_ty in
+           let right_ty = actual_ty right_ty in
+           match left_ty with
+           | Types.UNKNOWN ->
+               { exp = Translate.default_exp; ty = Types.INT }
+           | _ when Poly.equal right_ty Types.UNKNOWN ->
+               { exp = Translate.default_exp; ty = Types.INT }
+           | Types.INT | Types.STRING | Types.NIL | Types.RECORD _
           | Types.ARRAY _ ->
               if Types.equals (left_ty, right_ty) then (
                 match
@@ -199,15 +203,15 @@ module Semant : SEMANT = struct
                       exp = Translate.recordExp input_field_exps;
                       ty = record_type;
                     }
-              | _ ->
-                  ErrorMsg.error_pos pos
-                    (Printf.sprintf "invalid record type: %s"
-                       (Types.to_string record_type));
-                  { exp = Translate.default_exp; ty = Types.INT })
-          | None ->
-              ErrorMsg.error_pos pos
-                (Printf.sprintf "undefined type %s" (S.name typ));
-              { exp = Translate.default_exp; ty = Types.INT })
+               | _ ->
+                   ErrorMsg.error_pos pos
+                     (Printf.sprintf "invalid record type: %s"
+                        (Types.to_string record_type));
+                   { exp = Translate.default_exp; ty = record_type })
+           | None ->
+               ErrorMsg.error_pos pos
+                 (Printf.sprintf "undefined type %s" (S.name typ));
+               { exp = Translate.default_exp; ty = Types.UNKNOWN })
       | SeqExp exps ->
           (* Returns the NIL type for empty sequences *)
           let exps', ty =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -12,6 +12,7 @@ module Types = struct
     | ARRAY of ty * unique
     | NAME of Symbol.symbol * ty option ref
     | UNIT
+    | UNKNOWN
 
   let rec to_string = function
     | RECORD (fields, _) ->
@@ -26,6 +27,7 @@ module Types = struct
     | ARRAY (t, _) -> Printf.sprintf "ARRAY<%s>" (to_string t)
     | NAME (s, _) -> Printf.sprintf "NAME<%s>" (Symbol.name s)
     | UNIT -> "()"
+    | UNKNOWN -> "UNKNOWN"
 
   let equals = function
     | RECORD (_, u1), RECORD (_, u2) -> u1 = u2
@@ -34,6 +36,7 @@ module Types = struct
     | INT, INT -> true
     | STRING, STRING -> true
     | UNIT, UNIT -> true
+    | UNKNOWN, _ | _, UNKNOWN -> true
     | NAME (n1, _), NAME (n2, _) -> n1 = n2
     (* NIL is compatible with all RECORDS *)
     | NIL, RECORD _ -> true


### PR DESCRIPTION
Summary:
- retain the resolved type when a record literal names a non-record type
- add an UNKNOWN recovery type for undefined record types
- avoid emitting follow-on comparison errors for unknown operands

Testing:
- dune build lib/tiger.cma (blocked: local opam switch is missing expect_test_helpers_core)