### PR TITLE
Make nil assignable only to records

### DIFF
--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -48,7 +48,12 @@ module Semant : SEMANT = struct
   exception Semantic_error
 
   let check_type (required_type, { ty; _ }, pos, msg) =
-    if not @@ Types.equals (ty, required_type) then ErrorMsg.error_pos pos msg
+    if not @@ Types.is_assignable ~actual:ty ~required:required_type then
+      ErrorMsg.error_pos pos msg
+
+  let compatible_types ty1 ty2 =
+    Types.is_assignable ~actual:ty1 ~required:ty2
+    || Types.is_assignable ~actual:ty2 ~required:ty1
 
   let rec actual_ty = function
     | Types.NAME (_, t) -> (
@@ -103,7 +108,7 @@ module Semant : SEMANT = struct
           match left_ty with
           | Types.INT | Types.STRING | Types.NIL | Types.RECORD _
           | Types.ARRAY _ ->
-              if Types.equals (left_ty, right_ty) then (
+              if compatible_types left_ty right_ty then (
                 match
                   Translate.comparisonOperation
                     (left_exp, oper, right_exp, left_ty, right_ty)
@@ -178,7 +183,10 @@ module Semant : SEMANT = struct
                               let { exp; ty = ty' } = trexp e in
                               let ty = actual_ty ty in
                               let ty' = actual_ty ty' in
-                              if not (Types.equals (ty, ty')) then
+                              if
+                                not
+                                  (Types.is_assignable ~actual:ty' ~required:ty)
+                              then
                                 ErrorMsg.error_pos pos
                                   (Printf.sprintf
                                      "type mismatch for field '%s', expected \
@@ -229,7 +237,11 @@ module Semant : SEMANT = struct
             transVar (venv, tenv, senv, level, var)
           in
           let { ty = exp_type; exp = exp_exp } = trexp exp in
-          if not (Types.equals (actual_ty var_type, actual_ty exp_type)) then
+          if
+            not
+              (Types.is_assignable ~actual:(actual_ty exp_type)
+                 ~required:(actual_ty var_type))
+          then
             ErrorMsg.error_pos pos
               (Printf.sprintf
                  "type mismatch: tried to assign expression of type %s to \
@@ -251,14 +263,19 @@ module Semant : SEMANT = struct
           match else' with
           | Some e ->
               let else_expty = trexp e in
-              if not (Types.equals (then_expty.ty, else_expty.ty)) then
+              if not (compatible_types then_expty.ty else_expty.ty) then
                 ErrorMsg.error_pos (A.exp_pos then')
                   "type mismatch in then and else clause";
+              let ty =
+                match (then_expty.ty, else_expty.ty) with
+                | Types.NIL, (Types.RECORD _ as record) -> record
+                | _ -> then_expty.ty
+              in
               {
                 exp =
                   Translate.ifThenElse
                     (test_expty.exp, then_expty.exp, else_expty.exp);
-                ty = then_expty.ty;
+                ty;
               }
           | None ->
               check_type
@@ -381,7 +398,7 @@ module Semant : SEMANT = struct
     and processArg (exp, ty) =
       let { ty = exp_ty; exp = exp' } = trexp exp in
       let ty' = actual_ty ty in
-      if not (Types.equals (exp_ty, ty')) then
+      if not (Types.is_assignable ~actual:exp_ty ~required:ty') then
         ErrorMsg.error_pos (Absyn.exp_pos exp)
           (Printf.sprintf "Expected argument of type %s got %s instead"
              (Types.to_string ty') (Types.to_string exp_ty));
@@ -528,7 +545,9 @@ module Semant : SEMANT = struct
             in
             let body_expty = transExp (venv', tenv, senv, level', body) in
             let res_type = actual_ty result in
-            if not (Types.equals (res_type, body_expty.ty)) then
+            if
+              not (Types.is_assignable ~actual:body_expty.ty ~required:res_type)
+            then
               ErrorMsg.error_pos (A.exp_pos body)
                 (Printf.sprintf
                    "function return type does not match body, required %s got \
@@ -562,7 +581,9 @@ module Semant : SEMANT = struct
         let init_ty = actual_ty init_ty in
         (match Symbol.look (tenv, t) with
         | Some t' ->
-            if not @@ Types.equals (actual_ty t', init_ty) then
+            if
+              not (Types.is_assignable ~actual:init_ty ~required:(actual_ty t'))
+            then
               ErrorMsg.error_pos t_pos
                 (Printf.sprintf "type mismatch, expected %s but got %s instead"
                    (Symbol.name t) (Types.to_string init_ty))

--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -579,22 +579,27 @@ module Semant : SEMANT = struct
           transExp (venv, tenv, senv, level, init)
         in
         let init_ty = actual_ty init_ty in
-        (match Symbol.look (tenv, t) with
-        | Some t' ->
-            if
-              not (Types.is_assignable ~actual:init_ty ~required:(actual_ty t'))
-            then
+        let declared_ty =
+          match Symbol.look (tenv, t) with
+          | Some t' ->
+              let declared_ty = actual_ty t' in
+              if not (Types.is_assignable ~actual:init_ty ~required:declared_ty)
+              then
+                ErrorMsg.error_pos t_pos
+                  (Printf.sprintf
+                     "type mismatch, expected %s but got %s instead"
+                     (Symbol.name t) (Types.to_string init_ty));
+              declared_ty
+          | None ->
               ErrorMsg.error_pos t_pos
-                (Printf.sprintf "type mismatch, expected %s but got %s instead"
-                   (Symbol.name t) (Types.to_string init_ty))
-        | None ->
-            ErrorMsg.error_pos t_pos
-              (Printf.sprintf "undefined type: %s" (Symbol.name t)));
+                (Printf.sprintf "undefined type: %s" (Symbol.name t));
+              Types.INT
+        in
         let var_access = Translate.alloc_local level !escape in
         {
           venv =
             S.enter
-              (venv, name, E.VarEntry { ty = init_ty; access = var_access });
+              (venv, name, E.VarEntry { ty = declared_ty; access = var_access });
           tenv;
           senv;
           inits =

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -27,7 +27,8 @@ module Types = struct
     | NAME (s, _) -> Printf.sprintf "NAME<%s>" (Symbol.name s)
     | UNIT -> "()"
 
-  let equals = function
+  let is_assignable ~actual ~required =
+    match (actual, required) with
     | RECORD (_, u1), RECORD (_, u2) -> u1 = u2
     | ARRAY (_, u1), ARRAY (_, u2) -> u1 = u2
     | NIL, NIL -> true
@@ -35,9 +36,8 @@ module Types = struct
     | STRING, STRING -> true
     | UNIT, UNIT -> true
     | NAME (n1, _), NAME (n2, _) -> n1 = n2
-    (* NIL is compatible with all RECORDS *)
+    (* NIL can be used where a RECORD is expected, but not vice versa. *)
     | NIL, RECORD _ -> true
-    | RECORD _, NIL -> true
     | _ -> false
 
   let is_ptr = function RECORD _ | ARRAY _ | STRING -> true | _ -> false
@@ -73,3 +73,10 @@ let%test_unit "array_with_name_to_string" =
     Types.ARRAY (Types.NAME (Symbol.to_symbol "CUSTOM", ref None), ref ())
   in
   [%test_eq: string] (Types.to_string t) expected
+
+let%test_unit "nil is only compatible with expected records" =
+  let record = Types.RECORD ([], ref ()) in
+  [%test_eq: bool] (Types.is_assignable ~actual:Types.NIL ~required:record) true;
+  [%test_eq: bool]
+    (Types.is_assignable ~actual:record ~required:Types.NIL)
+    false

--- a/lib/types.ml
+++ b/lib/types.ml
@@ -27,6 +27,7 @@ module Types = struct
     | NAME (s, _) -> Printf.sprintf "NAME<%s>" (Symbol.name s)
     | UNIT -> "()"
 
+  (* Whether an actual value type can satisfy a required type. *)
   let is_assignable ~actual ~required =
     match (actual, required) with
     | RECORD (_, u1), RECORD (_, u2) -> u1 = u2

--- a/tests/integration/input/test-cons-list.tig
+++ b/tests/integration/input/test-cons-list.tig
@@ -5,9 +5,9 @@ let
   /* define a list */
   type stringlist = { hd : string, tl : stringlist } 
 
-  function reverse_list(l : stringlist) =
+  function reverse_list(l : stringlist) : stringlist =
     let
-      function reverse_aux(l : stringlist, acc : stringlist) =
+      function reverse_aux(l : stringlist, acc : stringlist) : stringlist =
         if l = nil then
           acc
         else


### PR DESCRIPTION
Summary:
- replace the symmetric `equals` predicate with `is_assignable ~actual ~required`
- allow `nil` only where a record is required
- reject records where a statement-like `nil` result is required
- preserve a declared variable type when its initializer is `nil`
- require explicit `stringlist` results in the cons-list integration program
- use bidirectional compatibility only when merging `if` branches or comparison operands

Testing:
- opam exec -- dune build
- opam exec -- dune runtest lib
- full `opam exec -- dune runtest` in the local `tiger-test-tools:local` Docker image