### PR TITLE
Translate expression sequences in linear time

### DIFF
--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -214,10 +214,10 @@ module Semant : SEMANT = struct
             List.fold_left
               ~f:(fun (l, _) (e, _) ->
                 let { exp; ty } = trexp e in
-                (l @ [ exp ], ty))
+                (exp :: l, ty))
               ~init:([], Types.NIL) exps
           in
-          { exp = Translate.seqExp exps'; ty }
+          { exp = Translate.seqExp (List.rev exps'); ty }
       | AssignExp { var; exp; pos } ->
           let { ty = var_type; exp = var_exp } =
             transVar (venv, tenv, senv, level, var)


### PR DESCRIPTION
Summary:
- prepend translated sequence expressions during traversal
- reverse once before lowering the sequence IR

Testing:
- not run (change is a list-construction optimization; shared test suite is blocked by a missing expect_test_helpers_core dependency)