### PR TITLE
Add runtime array bounds checks

### DIFF
--- a/btl/runtime.c
+++ b/btl/runtime.c
@@ -31,13 +31,20 @@ void print(struct tigerstr *s) {
 }
 
 int64_t *initArray(int64_t size, int64_t init) {
-  int i;
-  int64_t *a = (int64_t *)malloc(size * sizeof(int64_t));
+  int64_t *a = (int64_t *)malloc((size + 1) * sizeof(int64_t));
+  a[0] = size;
 
   for (int i = 0; i < size; i++)
-    a[i] = init;
+    a[i + 1] = init;
 
   return a;
+}
+
+void assert_array_index(const int64_t *array, int64_t index) {
+  if (array == NULL || index < 0 || index >= array[0]) {
+    fprintf(stderr, "Array index %lld is out of bounds.\n", index);
+    exit(1);
+  }
 }
 
 int *allocRecord(int size) {

--- a/lib/translate.ml
+++ b/lib/translate.ml
@@ -198,6 +198,7 @@ module Translate = struct
            T.MEM
              (binOpPlus (T.TEMP array)
                 (binOpMul (T.CONST Frame.word_size)
+                   (* Word zero holds the array length, so elements begin at index one. *)
                    (Tree.BINOP (Tree.PLUS, T.TEMP index, T.CONST 1)))) ))
 
   let fieldVar (var_exp, field_index) =

--- a/lib/translate.ml
+++ b/lib/translate.ml
@@ -177,18 +177,28 @@ module Translate = struct
   let binOpPlus e1 e2 = Tree.BINOP (Tree.PLUS, e1, e2)
   let binOpMul e1 e2 = Tree.BINOP (Tree.MUL, e1, e2)
 
-  (* TODO: Emit code for bounds checking.
-     Idea: Use the first word to store the array length
-     and use that to carry out bounds checking. *)
-  let subscriptVar (var_exp, index_exp) =
-    Ex
-      (T.MEM
-         (binOpPlus (unEx var_exp)
-            (binOpMul (T.CONST Frame.word_size) (unEx index_exp))))
-
   (* Assume that stdlib functions do not require a static link *)
   let callStdlibExp (name, args) =
     Ex (Frame.externalCall (name, List.map unEx args))
+
+  let subscriptVar (var_exp, index_exp) =
+    let array = Temp.new_temp () in
+    let index = Temp.new_temp () in
+    Ex
+      (T.ESEQ
+         ( seq
+             [
+               T.MOVE (T.TEMP array, unEx var_exp);
+               T.MOVE (T.TEMP index, unEx index_exp);
+               unNx
+                 (callStdlibExp
+                    ( "assert_array_index",
+                      [ Ex (T.TEMP array); Ex (T.TEMP index) ] ));
+             ],
+           T.MEM
+             (binOpPlus (T.TEMP array)
+                (binOpMul (T.CONST Frame.word_size)
+                   (Tree.BINOP (Tree.PLUS, T.TEMP index, T.CONST 1)))) ))
 
   let fieldVar (var_exp, field_index) =
     (* Store the record pointer in a register so we can


### PR DESCRIPTION
Summary:
- store each array length in an allocation header
- evaluate subscript operands once and validate the index before dereferencing
- terminate with a runtime error for null, negative, or out-of-range subscripts
