### PR TITLE
Align RISC-V stack frame allocations

### DIFF
--- a/lib/frame.ml
+++ b/lib/frame.ml
@@ -415,10 +415,11 @@ module RiscVFrame : FRAME = struct
       Int.max 0 (!max_num_parameters - List.length arg_regs)
     in
     let num_locals = !num_locals + max_params_on_stack in
-    (* TODO: Verify that we want this -1 *)
-    (* TODO: SP should always be 16-byte aligned according to
-       https://en.wikichip.org/wiki/risc-v/registers*)
-    let sp_offset = local_start_offset - (word_size * (num_locals - 1)) in
+    (* Local slots plus the saved caller frame pointer. *)
+    let frame_size = word_size * (num_locals + 1) in
+    (* RISC-V requires the stack pointer to be 16-byte aligned. *)
+    let aligned_frame_size = (frame_size + 15) land lnot 15 in
+    let sp_offset = -aligned_frame_size in
     let fn_header =
       Printf.sprintf "\t.text\n\t.globl\t%s\n\t.type\t%s, @function\n%s:\n" name
         name name
@@ -520,6 +521,24 @@ module RiscVFrame : FRAME = struct
     [%test_eq: register list]
       (List.map ~f:register_to_string_default callee_saves)
       expected
+
+  let%test_unit "stack frames are 16-byte aligned" =
+    let stack_allocation num_locals =
+      let frame = new_frame { name = Temp.new_label (); formals = [] } in
+      List.iter (List.init num_locals ~f:Fn.id) ~f:(fun _ ->
+          ignore (alloc_local frame true));
+      let { prolog; _ } = procEntryExit3 (frame, []) in
+      List.find_exn (String.split_lines prolog) ~f:(fun line ->
+          String.is_prefix line ~prefix:"\taddi sp")
+    in
+    [%test_eq: string list]
+      (List.map ~f:stack_allocation [ 0; 1; 2; 3 ])
+      [
+        "\taddi sp, sp, -16";
+        "\taddi sp, sp, -16";
+        "\taddi sp, sp, -32";
+        "\taddi sp, sp, -32";
+      ]
 end
 
 module Frame : FRAME = RiscVFrame

--- a/tests/codegen/expected/test_for_loop.s
+++ b/tests/codegen/expected/test_for_loop.s
@@ -2,9 +2,9 @@
 	.globl	tigermain
 	.type	tigermain, @function
 tigermain:
-	addi sp, sp, -24
-	sd fp, 16(sp)
-	addi fp, sp, 24
+	addi sp, sp, -32
+	sd fp, 24(sp)
+	addi fp, sp, 32
 
 L4:
 	sd a0, -16(fp)


### PR DESCRIPTION
Summary:
- derive frame allocation from saved frame pointer plus local slots
- round every allocation up to the RISC-V 16-byte ABI alignment
- cover zero through three local slots with an inline test

Testing:
- dune build lib/tiger.cma (blocked: local opam switch is missing expect_test_helpers_core)