### PR TITLE
Guard coalesced move filtering against uncolored temps

### DIFF
--- a/lib/regalloc.ml
+++ b/lib/regalloc.ml
@@ -100,7 +100,11 @@ module RegAlloc = struct
                   with
                   | Some src_reg, Some dst_reg ->
                       not (Frame.register_eq src_reg dst_reg)
-                  | _ -> true)
+                  | _ ->
+                      ErrorMsg.impossible
+                        (Printf.sprintf
+                           "uncolored move after register allocation: %s -> %s"
+                           (Temp.make_string src) (Temp.make_string dst)))
               | _ -> true)
         in
         (coalesced_instrs, allocation)

--- a/lib/regalloc.ml
+++ b/lib/regalloc.ml
@@ -93,13 +93,15 @@ module RegAlloc = struct
       if List.is_empty spills then
         let coalesced_instrs =
           List.filter instrs ~f:(fun instr ->
-               match instr with
-               | Assem.MOVE { dst; src; _ } -> (
-                   match Temp.look (allocation, src), Temp.look (allocation, dst) with
-                   | Some src_reg, Some dst_reg ->
-                       not (Frame.register_eq src_reg dst_reg)
-                   | _ -> true)
-               | _ -> true)
+              match instr with
+              | Assem.MOVE { dst; src; _ } -> (
+                  match
+                    (Temp.look (allocation, src), Temp.look (allocation, dst))
+                  with
+                  | Some src_reg, Some dst_reg ->
+                      not (Frame.register_eq src_reg dst_reg)
+                  | _ -> true)
+              | _ -> true)
         in
         (coalesced_instrs, allocation)
       else rewrite_program spills instrs frame flowgraph |> inner

--- a/lib/regalloc.ml
+++ b/lib/regalloc.ml
@@ -101,7 +101,7 @@ module RegAlloc = struct
                   | Some src_reg, Some dst_reg ->
                       not (Frame.register_eq src_reg dst_reg)
                   | _ ->
-                      ErrorMsg.impossible
+                      Errormsg.ErrorMsg.impossible
                         (Printf.sprintf
                            "uncolored move after register allocation: %s -> %s"
                            (Temp.make_string src) (Temp.make_string dst)))

--- a/lib/regalloc.ml
+++ b/lib/regalloc.ml
@@ -93,15 +93,13 @@ module RegAlloc = struct
       if List.is_empty spills then
         let coalesced_instrs =
           List.filter instrs ~f:(fun instr ->
-              match instr with
-              | Assem.MOVE { dst; src; _ }
-              (* Every temporary should have been assigned a register, so
-                 we should be able to use `look_exn`. *)
-                when Frame.register_eq
-                       (Temp.look_exn (allocation, src))
-                       (Temp.look_exn (allocation, dst)) ->
-                  false
-              | _ -> true)
+               match instr with
+               | Assem.MOVE { dst; src; _ } -> (
+                   match Temp.look (allocation, src), Temp.look (allocation, dst) with
+                   | Some src_reg, Some dst_reg ->
+                       not (Frame.register_eq src_reg dst_reg)
+                   | _ -> true)
+               | _ -> true)
         in
         (coalesced_instrs, allocation)
       else rewrite_program spills instrs frame flowgraph |> inner


### PR DESCRIPTION
Summary:
- use optional allocation lookups when eliminating coalesced moves
- retain a move whenever either endpoint has no assigned register

