### PR TITLE
Report unexpected semantic operator shapes clearly

### DIFF
--- a/lib/semant.ml
+++ b/lib/semant.ml
@@ -151,7 +151,7 @@ module Semant : SEMANT = struct
                 (left_expty.exp, oper, right_expty.exp);
             ty = Types.INT;
           }
-      | A.OpExp _ -> raise Internal_error
+      | A.OpExp _ -> ErrorMsg.impossible "unexpected OpExp shape in semant"
       | A.RecordExp { fields = input_fields; typ; pos } -> (
           match Symbol.look (tenv, typ) with
           | Some t -> (


### PR DESCRIPTION
Summary:
- replace the bare internal exception for unmatched operators
- surface the invariant violation through ErrorMsg.impossible

Testing:
- not run (unreachable defensive error-path change; shared test suite is blocked by a missing expect_test_helpers_core dependency)