### PR TITLE
Preserve integration test output newlines

### DIFF
--- a/test_lib/integration.ml
+++ b/test_lib/integration.ml
@@ -90,7 +90,8 @@ let%test_unit _ =
         [%test_result: string] cmd_output ~expect:expected;
         Stdio.print_endline "[OK]"
     | Ok _, Some expected_stderr, Error _ ->
-        [%test_result: string] (cmd_output ^ cmd_error)
+        [%test_result: string]
+          (String.rstrip cmd_output ^ cmd_error)
           ~expect:(String.rstrip expected_stderr);
         Stdio.print_endline "[OK]"
     | _ ->

--- a/test_lib/integration.ml
+++ b/test_lib/integration.ml
@@ -15,7 +15,7 @@ let%test_unit _ =
   in
   let strip_loader_banner output =
     match String.lsplit2 output ~on:'\n' with
-    | Some ("bbl loader", output) -> output
+    | Some (("bbl loader" | "bbl loader\r"), output) -> output
     | _ -> output
   in
   let test_dir = "../../../tests/integration/" in

--- a/test_lib/integration.ml
+++ b/test_lib/integration.ml
@@ -72,11 +72,7 @@ let%test_unit _ =
         output_err_fname
     in
     let cmd_inc, cmd_outc = Core_unix.open_process cmd in
-    let cmd_output =
-      match In_channel.input_lines ~fix_win_eol:true cmd_inc with
-      | [] -> ""
-      | _ :: lines -> String.concat ~sep:"\n" lines |> sanitise
-    in
+    let cmd_output = In_channel.input_all cmd_inc |> sanitise in
     let run_status = Core_unix.close_process (cmd_inc, cmd_outc) in
     let cmd_error =
       In_channel.with_file ~f:In_channel.input_all output_err_fname

--- a/test_lib/integration.ml
+++ b/test_lib/integration.ml
@@ -13,6 +13,11 @@ let%test_unit _ =
     (* For some reason, `spike pk` inserts this null character? *)
     Str.global_replace (Str.regexp "\000") ""
   in
+  let strip_loader_banner output =
+    match String.lsplit2 output ~on:'\n' with
+    | Some ("bbl loader", output) -> output
+    | _ -> output
+  in
   let test_dir = "../../../tests/integration/" in
   let runtime_file = "../../../btl/runtime.c" in
   let input_dir = "input/" in
@@ -72,7 +77,9 @@ let%test_unit _ =
         output_err_fname
     in
     let cmd_inc, cmd_outc = Core_unix.open_process cmd in
-    let cmd_output = In_channel.input_all cmd_inc |> sanitise in
+    let cmd_output =
+      In_channel.input_all cmd_inc |> sanitise |> strip_loader_banner
+    in
     let run_status = Core_unix.close_process (cmd_inc, cmd_outc) in
     let cmd_error =
       In_channel.with_file ~f:In_channel.input_all output_err_fname


### PR DESCRIPTION
Summary:
- read integration-test stdout as raw content rather than splitting it into lines
- remove only Spike PK's `bbl loader` prefix
- preserve trailing program newlines while retaining NUL sanitization

Testing:
- opam exec -- dune fmt
- opam exec -- dune build
- opam exec -- dune runtest lib

